### PR TITLE
Do NOT use qt5_use_modules to link SortFilterProxyModel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,4 +49,3 @@ target_include_directories(SortFilterProxyModel PUBLIC
     )
 
 set_property(TARGET SortFilterProxyModel PROPERTY POSITION_INDEPENDENT_CODE ON)
-qt5_use_modules(SortFilterProxyModel Core Qml)


### PR DESCRIPTION
As it is an OBJECT library, it must NOT be linked to. It should instead be used as:
add_executable(${PROJECT_NAME} $<TARGET_OBJECTS:SortFilterProxyModel>)